### PR TITLE
Add option to log caller threads

### DIFF
--- a/thread-origin-agent/src/main/java/software/xdev/tools/threadoriginagent/ThreadOriginTransformer.java
+++ b/thread-origin-agent/src/main/java/software/xdev/tools/threadoriginagent/ThreadOriginTransformer.java
@@ -40,8 +40,17 @@ public class ThreadOriginTransformer implements ClassFileTransformer
 		System.getProperty("TOA_DISPLAY_METHOD_INSTRUMENTATION_FAILURES") != null;
 	private static final boolean LOG_THREAD_JOINS =
 		System.getProperty("TOA_LOG_THREAD_JOINS") != null;
+	private static final boolean LOG_CALLER_THREADS =
+		System.getProperty("TOA_LOG_CALLER_THREADS") != null;
 	
 	private static final String PROCEED = "$proceed($$); ";
+	
+	private static final String PRINT_CALLER_THREAD = LOG_CALLER_THREADS
+		? "java.lang.Thread currentThread = java.lang.Thread.currentThread(); "
+			+ "System.out.println(\"[TOA] Called from \" + currentThread.getClass().getName() + "
+			+ "\" id: \" + currentThread.getId() + "
+			+ "\" name: \" + currentThread.getName()); "
+		: "";
 	
 	private static final String PRINT_STACK =
 		"java.lang.StackTraceElement[] elements = java.lang.Thread.currentThread().getStackTrace(); "
@@ -237,6 +246,7 @@ public class ThreadOriginTransformer implements ClassFileTransformer
 				+ declaringClass.getName()
 				+ ".start() id: \" + ((Thread)$0).getId() + \" name: \" + "
 				+ "((Thread)$0).getName()); "
+				+ PRINT_CALLER_THREAD
 				+ PRINT_STACK
 				+ PROCEED
 				+ "} ");
@@ -248,6 +258,7 @@ public class ThreadOriginTransformer implements ClassFileTransformer
 				+ declaringClass.getName()
 				+ ".join() id: \" + ((Thread)$0).getId() + \" name: \" + "
 				+ "((Thread)$0).getName()); "
+				+ PRINT_CALLER_THREAD
 				+ PROCEED
 				+ "} ");
 		}


### PR DESCRIPTION
This PR adds an option to log caller thread names and IDs.
The feature is enabled via the property `TOA_LOG_CALLER_THREADS`, analogously to how the property `TOA_LOG_THREAD_JOINS` is used.

For every thread start (and join if enabled), a single additional line is logged.

```
[TOA] Detected java.lang.Thread.start() id: 86 name: Timer-0
[TOA] Called from java.lang.Thread id: 1 name: main                                       <<< this line is new
[TOA]   java.base/java.util.Timer.<init>(timer.java:188)
[TOA]   ...
```